### PR TITLE
Bug/message errorhandling

### DIFF
--- a/pages/api/messages.js
+++ b/pages/api/messages.js
@@ -3,7 +3,7 @@ export default async function handler(req, res) {
   const { id, locale } = req?.query
   let messages = []
   // No posts allowed, no missing params-errors revealed.
-  if (req.method !== 'GET' || !id || !locale) {
+  if (req.method !== 'GET' || !locale) {
     res.status(400).json(messages)
     return
   }

--- a/pages/api/messages.js
+++ b/pages/api/messages.js
@@ -1,14 +1,15 @@
 import { getMessages } from '@/lib/ssr-api'
 export default async function handler(req, res) {
   const { id, locale } = req?.query
+  let messages = []
   // No posts allowed, no missing params-errors revealed.
   if (req.method !== 'GET' || !id || !locale) {
-    res.status(400).json([])
+    res.status(400).json(messages)
     return
   }
   let status = 200
-  // let messages = []
-  const messages = await getMessages({ locale, id }).catch((e) => {
+
+  messages = await getMessages({ locale, id }).catch((e) => {
     console.error('Messages error', e)
     return []
   })

--- a/pages/api/messages.js
+++ b/pages/api/messages.js
@@ -1,9 +1,9 @@
 import { getMessages } from '@/lib/ssr-api'
 export default async function handler(req, res) {
   const { id, locale } = req?.query
-  // No posts allowed
+  // No posts allowed, no missing params-errors revealed.
   if (req.method !== 'GET' || !id || !locale) {
-    res.status(400).end()
+    res.status(400).json([])
     return
   }
   let status = 200

--- a/src/components/feedback/FeedbackForm.jsx
+++ b/src/components/feedback/FeedbackForm.jsx
@@ -14,6 +14,9 @@ import { feedbackEmailAtom } from '@/src/store'
 import { useAtomValue } from 'jotai/utils'
 // eslint-disable-next-line react/display-name
 const FeedbackForm = forwardRef(({ onCancel }, ref) => {
+  // DEV NOTE: needs recomposition.
+  // Currently CSSTransition causes useSWR to refetch every time it is opened.
+
   const { t } = useTranslation('common')
   const feedbackEmail = useAtomValue(feedbackEmailAtom)
   const pageUrl = isSSR() === false ? window.location.href : ''

--- a/src/components/feedback/FeedbackForm.jsx
+++ b/src/components/feedback/FeedbackForm.jsx
@@ -14,8 +14,10 @@ import { feedbackEmailAtom } from '@/src/store'
 import { useAtomValue } from 'jotai/utils'
 // eslint-disable-next-line react/display-name
 const FeedbackForm = forwardRef(({ onCancel }, ref) => {
-  // DEV NOTE: needs recomposition.
-  // Currently CSSTransition causes useSWR to refetch every time it is opened.
+
+// DEV NOTE: needs recomposition.
+// Currently CSSTransition causes useSWR to refetch every time it is opened.
+// Consider using async atom and useAtom hook instead if this becomes a real issue.
 
   const { t } = useTranslation('common')
   const feedbackEmail = useAtomValue(feedbackEmailAtom)

--- a/src/components/feedback/FeedbackForm.jsx
+++ b/src/components/feedback/FeedbackForm.jsx
@@ -14,10 +14,9 @@ import { feedbackEmailAtom } from '@/src/store'
 import { useAtomValue } from 'jotai/utils'
 // eslint-disable-next-line react/display-name
 const FeedbackForm = forwardRef(({ onCancel }, ref) => {
-
-// DEV NOTE: needs recomposition.
-// Currently CSSTransition causes useSWR to refetch every time it is opened.
-// Consider using async atom and useAtom hook instead if this becomes a real issue.
+  // DEV NOTE: needs recomposition.
+  // Currently CSSTransition causes useSWR to refetch every time it is opened.
+  // Consider using async atom and useAtom hook instead if this becomes a real issue.
 
   const { t } = useTranslation('common')
   const feedbackEmail = useAtomValue(feedbackEmailAtom)

--- a/src/components/messages/Messages.jsx
+++ b/src/components/messages/Messages.jsx
@@ -23,10 +23,12 @@ const Error = () => (
 const Messages = () => {
   const { t } = useTranslation('common')
   const id = useAtomValue(nodeIdAtom)
-  const { locale } = useRouter()
+  const { locale, asPath } = useRouter()
   const fetcher = () => getMessages({ id, locale })
-  const cacheKey = () => (id ? `/${locale}/${id}` : null)
-  const { data, error, isValidating } = useSWR(cacheKey(), fetcher)
+  const { data, error, isValidating } = useSWR(
+    `/${locale}/${id || asPath}`,
+    fetcher
+  )
 
   const [shownMessages, setShownMessages] = useAtom(shownMessagesAtom)
 

--- a/src/components/messages/Messages.jsx
+++ b/src/components/messages/Messages.jsx
@@ -25,7 +25,8 @@ const Messages = () => {
   const id = useAtomValue(nodeIdAtom)
   const { locale } = useRouter()
   const fetcher = () => getMessages({ id, locale })
-  const { data, error, isValidating } = useSWR(`/${locale}/${id}`, fetcher)
+  const cacheKey = () => (id ? `/${locale}/${id}` : null)
+  const { data, error, isValidating } = useSWR(cacheKey(), fetcher)
 
   const [shownMessages, setShownMessages] = useAtom(shownMessagesAtom)
 

--- a/src/lib/ssr-api.js
+++ b/src/lib/ssr-api.js
@@ -122,6 +122,12 @@ export const getMessages = async ({ locale, id }) => {
     throw e
   })
 
+  const idlist = [frontPageNode.entity.uuid]
+
+  if (id) {
+    idlist.push(id)
+  }
+
   const params = new DrupalJsonApiParams()
     .addFields(NODE_TYPES.MESSAGE, [
       'body',
@@ -133,7 +139,7 @@ export const getMessages = async ({ locale, id }) => {
     // Show warnings first, then notifications
     .addSort('field_message_type', 'DESC')
     .addSort('id', 'ASC')
-    .addFilter('field_page.id', [id, frontPageNode.entity.uuid], 'IN')
+    .addFilter('field_page.id', idlist, 'IN')
     .getQueryObject()
 
   return getResourceCollection(NODE_TYPES.MESSAGE, {


### PR DESCRIPTION
- matomo tracks correctly and only with explicit user consent
- fixed bug in messages.js parameter hanlding. Allow global messages for non-drupal pages