### PR TITLE
Feature/ifu 696 block node id requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,3 +282,9 @@ module.exports = {
 The root page of the site is mapped to a specific `node` in in drupal instance. The default value in drupal should be set to a Landing Page type, assumed `/landingpage`
 
 Make sure your drupal instance contains one `Landing Page` with matching url to Drupal Basic Settings:: Front Page (`/landingpage` by convention).
+
+## Search
+
+### Indexing
+
+TODO

--- a/next.config.js
+++ b/next.config.js
@@ -42,6 +42,7 @@ const serverRuntimeConfig = {
   DRUPAL_CLIENT_ID: process.env.DRUPAL_CLIENT_ID,
   DRUPAL_PREVIEW_SECRET: process.env.DRUPAL_PREVIEW_SECRET,
   DRUPAL_CLIENT_SECRET: process.env.DRUPAL_CLIENT_SECRET,
+  SEARCH_INDEX_PREFIX: process.env.SEARCH_INDEX_PREFIX,
   ...publicRuntimeConfig,
   ...env,
 }

--- a/pages/404.jsx
+++ b/pages/404.jsx
@@ -7,11 +7,13 @@ import { i18n } from '@/next-i18next.config'
 import { map, omit } from 'lodash'
 import { getMenus } from '@/lib/ssr-api'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-// import getConfig from 'next/config'
-import usePageLocales from '@/hooks/usePageLocales'
+
 import TextLink from '@/components/TextLink'
 import { DotsLoader } from '@/components/Loaders'
 import Block from '@/components/layout/Block'
+import { getLocalesForPath } from '@/lib/client-api'
+import useSWR from 'swr'
+
 export async function getStaticProps(context) {
   // const { serverRuntimeConfig } = getConfig()
   const menus = await getMenus(context)
@@ -146,6 +148,10 @@ const LocalesLinks = ({ locales, dir }) => {
     <p className="mt-2 leading-loose">
       {locales.map(({ locale, path, id }, i) => {
         const language = i18n.languages.find(({ code }) => code === locale)
+        console.log({ locale })
+        if (!language) {
+          return null
+        }
         return (
           <TextLink
             dir={dir}
@@ -260,7 +266,9 @@ const Texts404 = ({ locales = [], locale }) => {
 
 export const PageNotFound = () => {
   const { locale, asPath } = useRouter()
-  const { data: locales, error } = usePageLocales({ path: asPath })
+  const cacheKey = asPath ? asPath : null
+  const fetcher = () => getLocalesForPath({ path: asPath })
+  const { data: locales, error } = useSWR(cacheKey, fetcher)
 
   return (
     <Layout>

--- a/pages/404.jsx
+++ b/pages/404.jsx
@@ -148,7 +148,6 @@ const LocalesLinks = ({ locales, dir }) => {
     <p className="mt-2 leading-loose">
       {locales.map(({ locale, path, id }, i) => {
         const language = i18n.languages.find(({ code }) => code === locale)
-        console.log({ locale })
         if (!language) {
           return null
         }

--- a/pages/api/available-locales.js
+++ b/pages/api/available-locales.js
@@ -16,7 +16,6 @@ export default async function handler(req, res) {
   const nodes = await Promise.all(
     i18n.locales.map(async (locale) => {
       const localePath = `/${locale}${path}`
-      console.log({ localePath })
       const node = await translatePath(localePath)
       return { locale, node }
     })
@@ -24,8 +23,6 @@ export default async function handler(req, res) {
     console.error('Error while resolving locales for', path, e)
     throw e
   })
-
-  console.log(nodes)
 
   if (nodes === null) {
     status = 404

--- a/src/components/feedback/FeedbackForm.jsx
+++ b/src/components/feedback/FeedbackForm.jsx
@@ -84,7 +84,11 @@ const FeedbackForm = forwardRef(({ onCancel }, ref) => {
           )}
 
           <form onSubmit={handleSubmit(onSubmit, onError)}>
-            <input type="hidden" {...register('page')} value={pageUrl.split('#').shift()} />
+            <input
+              type="hidden"
+              {...register('page')}
+              value={pageUrl.split('#').shift()}
+            />
             <input
               type="hidden"
               {...register('subject')}

--- a/src/components/feedback/FeedbackForm.jsx
+++ b/src/components/feedback/FeedbackForm.jsx
@@ -84,7 +84,7 @@ const FeedbackForm = forwardRef(({ onCancel }, ref) => {
           )}
 
           <form onSubmit={handleSubmit(onSubmit, onError)}>
-            <input type="hidden" {...register('page')} value={pageUrl} />
+            <input type="hidden" {...register('page')} value={pageUrl.split('#').shift()} />
             <input
               type="hidden"
               {...register('subject')}

--- a/src/components/languages/LanguageSelector.jsx
+++ b/src/components/languages/LanguageSelector.jsx
@@ -2,14 +2,17 @@ import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { IconGlobe } from '@/components/Icons'
 import cls from 'classnames'
-import usePageLocales from '@/hooks/usePageLocales'
 import { useTranslation } from 'next-i18next'
 import { i18n } from '@/next-i18next.config'
+import { getLocalesForPath } from '@/lib/client-api'
+import useSWR from 'swr'
 
 const LanguageSelector = ({ openMenu }) => {
   const { locale, asPath: path } = useRouter()
   const { t } = useTranslation('common')
-  const { data: locales, error } = usePageLocales({ path })
+  const cacheKey = path ? path : null
+  const fetcher = () => getLocalesForPath({ path })
+  const { data: locales, error } = useSWR(cacheKey, fetcher)
 
   return (
     <>

--- a/src/components/search/TopSearch.jsx
+++ b/src/components/search/TopSearch.jsx
@@ -185,7 +185,7 @@ export const SWRResults = ({ onShowResults }) => {
 
   if (isValidating) {
     return (
-      <div className="flex items-center mx-4 h-16">
+      <div className="flex items-center mx-4 max-w-topbar h-16">
         <DotsLoader />{' '}
       </div>
     )

--- a/src/lib/elasticsearch.js
+++ b/src/lib/elasticsearch.js
@@ -2,13 +2,14 @@ import getConfig from 'next/config'
 import { Client } from '@elastic/elasticsearch'
 import { HIGHLIGHT_CLASS } from '@/components/search/Result'
 import { isString } from 'lodash'
-// import { siteUrl } from '@/next-sitemap'
 
 const DEFAULT_SIZE = 30
 const DEFAULT_FROM = 0
-const INDEX_PREFIX = 'first_'
 
-export const getIndexName = (locale) => `${INDEX_PREFIX}${locale}`
+const getIndexPrefix = () =>
+  getConfig().serverRuntimeConfig.SEARCH_INDEX_PREFIX || 'first_'
+
+export const getIndexName = (locale) => `${getIndexPrefix()}${locale}`
 export const HIGHLIGHT_FRAGMENT_SIZE = 3000
 export const HIGHLIGHT_NUM_OF_FRAGMENTS = 10
 export const ERROR = 'Error: Elastic Search query failed. '
@@ -70,10 +71,6 @@ export const getSearchClient = () => {
       ca: elasticsearch_certificate,
       rejectUnauthorized: false,
     },
-    // ssl: {
-    //   ca: elasticsearch_certificate,
-    //   rejectUnauthorized: false,
-    // },
   })
 }
 


### PR DESCRIPTION
- available locales check now ignores duplicate locales. Fixes bug where router returns  defaultLocale for missing page localization where it should not.
- elasticsearch index prefix can be set from ENV using SEARCH_INDEX_PREFIX
- block all request to /node/[nodeid] paths. return 404. This fixes cases where menu is showing a node/nodeid path for a page without localized content.