### PR TITLE
redirect node/id paths to node.path.alias if available. return 404 if…

### DIFF
--- a/pages/[[...slug]].jsx
+++ b/pages/[[...slug]].jsx
@@ -59,12 +59,7 @@ export async function getStaticProps(context) {
   const { params, locale } = context
   params.slug = params.slug || ['/']
   const path = params.slug.join('/')
-  if (/node/.test(params.slug[0])) {
-    console.warn(
-      `Warning: request to direct node ${path} blocked. 404 returned `
-    )
-    return NOT_FOUND
-  }
+  const isNodePath = /node/.test(params.slug[0])
 
   const type = await getResourceTypeFromContext({
     locale,
@@ -100,6 +95,21 @@ export async function getStaticProps(context) {
   if (!node) {
     console.warn(`Warning: no valid node for /${locale}/${path}`)
     return NOT_FOUND
+  }
+
+  if (isNodePath) {
+    if (node.path?.alias) {
+      return {
+        redirect: {
+          permanent: false,
+          destination: `/${locale}/${node.path.alias}`,
+        },
+      }
+    } else {
+      console.warn(
+        `Warning: request to direct node ${path} blocked. 404 returned `
+      )
+    }
   }
 
   let fiNode = null // Must be JSON compatible

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,7 +12,6 @@ import useAnalytics from '@/hooks/useAnalytics'
  * Subscribe NProgress loader bar to Router events
  *
  */
-
 NProgress.configure({ showSpinner: false })
 Router.events.on('routeChangeStart', () => NProgress.start())
 Router.events.on('routeChangeComplete', () => NProgress.done())

--- a/src/lib/elasticsearch.js
+++ b/src/lib/elasticsearch.js
@@ -7,7 +7,7 @@ const DEFAULT_SIZE = 30
 const DEFAULT_FROM = 0
 
 const getIndexPrefix = () =>
-  getConfig().serverRuntimeConfig.SEARCH_INDEX_PREFIX || 'first_'
+  getConfig().serverRuntimeConfig.SEARCH_INDEX_PREFIX || ''
 
 export const getIndexName = (locale) => `${getIndexPrefix()}${locale}`
 export const HIGHLIGHT_FRAGMENT_SIZE = 3000


### PR DESCRIPTION
… no alias is set. Set search index prefix from env variables