### PR TITLE
 disabled/supported locales for somalian error- and 404-messages

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -6,7 +6,7 @@ const languages = [
   { code: 'et', text: 'Eesti keel' },
   { code: 'uk', text: 'Українська' },
   { code: 'fr', text: 'Français' },
-  // { code: 'so', text: 'Soomaali' },
+  { code: 'so', text: 'Soomaali' },
   { code: 'es', text: 'Español' },
   { code: 'tr', text: 'Türkçe' },
   { code: 'zh', text: '中文' },
@@ -14,7 +14,15 @@ const languages = [
   { code: 'ar', text: 'العربية' },
 ]
 const rtlLocales = ['ar', 'fa']
+const disabledLocales = ['so']
 const locales = languages.map(({ code }) => code)
+const supportedLanguages = languages.filter(
+  ({ code }) => !disabledLocales.includes(code)
+)
+const supportedLocales = locales.filter(
+  (code) => !disabledLocales.includes(code)
+)
+
 const DIRECTION_LTR = 'ltr'
 const DIRECTION_RTL = 'rtl'
 
@@ -23,6 +31,9 @@ module.exports = {
     reloadOnPrerender: process.env.NODE_ENV === 'development',
     locales,
     languages,
+    disabledLocales,
+    supportedLocales,
+    supportedLanguages,
     rtlLocales,
     defaultLocale: 'en',
     fallbackLocale: 'fi',

--- a/next.config.js
+++ b/next.config.js
@@ -86,6 +86,16 @@ const config = {
     config.module.rules.push({ test: /\.xml$/, loader: 'xml-loader' })
     return config
   },
+  async redirects() {
+    return [
+      {
+        source: '/so',
+        locale: false,
+        destination: '/so/not-supported',
+        permanent: false,
+      },
+    ]
+  },
 }
 
 module.exports = withBundleAnalyzer(config)

--- a/next.config.js
+++ b/next.config.js
@@ -92,7 +92,7 @@ const config = {
         source: '/so',
         locale: false,
         destination: '/so/not-supported',
-        permanent: false,
+        permanent: true,
       },
     ]
   },

--- a/pages/404.jsx
+++ b/pages/404.jsx
@@ -185,8 +185,6 @@ const Texts404 = ({ locales = [], locale, path }) => {
   // if there are no localizations, show basic-404
   // if all localizations exist, page is not shown for other reasons. Show basic 404
   // if some localizations exist, show available-languages-404
-
-  console.log({ l: locales.length, i18n: i18n.locales.length })
   const texts =
     locales.length > 0 || locales.length === i18n.locales.length
       ? TEXTS_LANG_404

--- a/pages/404.jsx
+++ b/pages/404.jsx
@@ -185,6 +185,8 @@ const Texts404 = ({ locales = [], locale, path }) => {
   // if there are no localizations, show basic-404
   // if all localizations exist, page is not shown for other reasons. Show basic 404
   // if some localizations exist, show available-languages-404
+
+  console.log({ l: locales.length, i18n: i18n.locales.length })
   const texts =
     locales.length > 0 || locales.length === i18n.locales.length
       ? TEXTS_LANG_404

--- a/src/components/home/CitySelector.jsx
+++ b/src/components/home/CitySelector.jsx
@@ -5,12 +5,18 @@ import Image from 'next/image'
 import Block from '@/components/layout/Block'
 import getConfig from 'next/config'
 import { useTranslation } from 'next-i18next'
+import { i18n } from '@/next-i18next.config'
 
 const CitySelector = () => {
   const { CITIES_PAGE_PATH } = getConfig().publicRuntimeConfig
-  const { push } = useRouter()
-  const goToCities = () => push(CITIES_PAGE_PATH)
   const { t } = useTranslation('common')
+  const router = useRouter()
+  let locale = router.locale
+
+  if (i18n.disabledLocales.includes(locale)) {
+    return null
+  }
+  const goToCities = () => router.push(CITIES_PAGE_PATH)
 
   return (
     <Block className="pt-8 border-t border-gray-darker">

--- a/src/components/layout/TopMenu.jsx
+++ b/src/components/layout/TopMenu.jsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import { useTranslation } from 'next-i18next'
 import useLangMenuToggle from '@/hooks/useLangMenuToggle'
 import MobileNavi from '@/components/navi/MobileNavi'
@@ -28,23 +27,22 @@ const Logo = () => {
       className="relative z-20 flex-none py-3 md:py-4 px-3 bg-white transform translate-y-px md:ps-6 md:pe-2"
       role="banner"
     >
-      <Link href={`/${locale}`} passHref prefetch={false} locale={locale}>
-        <a
-          className={cls('ifu-topmenu__logo', {
-            'ifu-topmenu__logo--loading': pageIsLoading,
-          })}
-          title={t('breadcrumbs.frontpage')}
-        >
-          {pageIsLoading && (
-            <span className=" hidden lg:inline-block relative -translate-x-1 -translate-y-5">
-              <span className="absolute left-20 w-1 h-1 bg-red rounded animate-ping"></span>
-              <span className="absolute left-24 w-1 h-1 bg-blue rounded animate-ping"></span>
-              <span className="absolute left-28 w-1 h-1 bg-green rounded animate-ping"></span>
-              <span className="absolute left-32 w-1 h-1 bg-orange rounded animate-ping"></span>
-            </span>
-          )}
-        </a>
-      </Link>
+      <a
+        href={`/${locale}`}
+        className={cls('ifu-topmenu__logo', {
+          'ifu-topmenu__logo--loading': pageIsLoading,
+        })}
+        title={t('breadcrumbs.frontpage')}
+      >
+        {pageIsLoading && (
+          <span className=" hidden lg:inline-block relative -translate-x-1 -translate-y-5">
+            <span className="absolute left-20 w-1 h-1 bg-red rounded animate-ping"></span>
+            <span className="absolute left-24 w-1 h-1 bg-blue rounded animate-ping"></span>
+            <span className="absolute left-28 w-1 h-1 bg-green rounded animate-ping"></span>
+            <span className="absolute left-32 w-1 h-1 bg-orange rounded animate-ping"></span>
+          </span>
+        )}
+      </a>
     </div>
   )
 }

--- a/src/components/layout/languages/LanguageMenu.jsx
+++ b/src/components/layout/languages/LanguageMenu.jsx
@@ -82,7 +82,6 @@ export const LangMenuDrawer = ({ closeMenu, isOpen }) => (
 )
 
 export const LanguageMenuButton = ({ onClick }) => {
-  console.log(i18n.supportedLanguages)
   const { t } = useTranslation('common')
   let { locale } = useRouter()
   if (i18n.disabledLocales.includes(locale)) {

--- a/src/components/layout/languages/LanguageMenu.jsx
+++ b/src/components/layout/languages/LanguageMenu.jsx
@@ -33,7 +33,7 @@ export const LanguageMenu = ({ closeMenu }) => {
       <label className="block px-14 mb-8 text-body-large font-bold">
         {t('languageMenu.label')}
       </label>
-      {i18n.languages.map((lang) => {
+      {i18n.supportedLanguages.map((lang) => {
         const { text, code } = lang
         const isSelected = locale === code
         return (
@@ -82,10 +82,15 @@ export const LangMenuDrawer = ({ closeMenu, isOpen }) => (
 )
 
 export const LanguageMenuButton = ({ onClick }) => {
+  console.log(i18n.supportedLanguages)
   const { t } = useTranslation('common')
-  const { locale } = useRouter()
-  const { text } = i18n.languages.find(({ code }) => code === locale)
-  const assisted = i18n.languages.filter(({ code }) => code !== locale)
+  let { locale } = useRouter()
+  if (i18n.disabledLocales.includes(locale)) {
+    locale = i18n.defaultLocale
+  }
+
+  const { text } = i18n.supportedLanguages.find(({ code }) => code === locale)
+  const assisted = i18n.supportedLanguages.filter(({ code }) => code !== locale)
   return (
     <button
       aria-haspopup="dialog"

--- a/src/components/layout/languages/LanguageSelector.jsx
+++ b/src/components/layout/languages/LanguageSelector.jsx
@@ -30,7 +30,7 @@ const LanguageSelector = ({ openMenu }) => {
           </span>
           <IconGlobe className="xl:hidden mx-2 xl:mx-0 w-5 h-5" />
         </button>
-        {i18n.languages.map(({ text, code }) => {
+        {i18n.supportedLanguages.map(({ text, code }) => {
           const isLocalized =
             locales?.find((page) => page?.locale === code) !== undefined
           return (

--- a/src/components/search/LanguageFilters.jsx
+++ b/src/components/search/LanguageFilters.jsx
@@ -5,7 +5,7 @@ import { IconGlobe } from '../Icons'
 import { IconCircleArrowRight } from '../Icons'
 import { useRouter } from 'next/router'
 const getLangMap = (languages) =>
-  i18n.locales.reduce((obj, lang) => {
+  i18n.supportedLocales.reduce((obj, lang) => {
     obj[lang] = languages?.includes(lang)
     return obj
   }, {})
@@ -42,7 +42,7 @@ const LanguageFilters = () => {
         </button>
       )}
       {show &&
-        i18n.languages.map(({ code, text }) => {
+        i18n.supportedLanguages.map(({ code, text }) => {
           const id = `query-lang-${code}`
 
           return (


### PR DESCRIPTION
- Adds disabledLocales, supportedLocales and supportedLanguages to next-i18next config
- Change language menus to use supportedLocales/Languages
- Change homepage CitySelector block to skip out of disabled locales
- Add redirect-rule for /so landingpage to so/not-supported
- Change Logo <Link> component to passive <a> tag to ensure redirect is not bypassed (router serves finnish landing page instead of redirect if /so is called from router :shrug: )