### PR TITLE
FE: Bugfix: IFU-885 - updated ukranian translation

### DIFF
--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -49,7 +49,7 @@
     "info2": "!Nimi, sähköposti ja palautteen teksti ovat kaikki pakollisia tietoja.",
     "labels": {
       "email": "Ел. пошта",
-      "feedback": "!Palautteesi",
+      "feedback": "Відгук",
       "name": "Ім'я"
     },
     "states": {


### PR DESCRIPTION
This has already been merged to the develop branch. https://github.com/City-of-Helsinki/infofinland-ui/pull/238

Updated ukranian translation for feedback form. 2 translations remain, but may not be used.

Testing instructions:
- go to frontend
- Change to Ukrainian language (confusingly the URL is /uk)
- Scroll to bottom of page and open the feedback form (blue)
- Verify that the label for the textarea on the lower left says "Відгук" instead of "!Palautteesi"