### PR TITLE
IFU-876: Remove the invisible links (under Oulu) and add more whitespace

### DIFF
--- a/src/components/navi/MenuGroup.jsx
+++ b/src/components/navi/MenuGroup.jsx
@@ -8,7 +8,7 @@ const MenuGroup = ({ menulist }) => {
         {...menu}
         key={`mainmenu-${i}`}
         useTopBorder={i > 0}
-        className={i + 1 === l ? 'mb-48' : ''}
+        className={i + 1 === l ? 'mb-52 pb-52' : ''}
       />
     )
   })

--- a/src/components/navi/MenuGroup.jsx
+++ b/src/components/navi/MenuGroup.jsx
@@ -8,7 +8,7 @@ const MenuGroup = ({ menulist }) => {
         {...menu}
         key={`mainmenu-${i}`}
         useTopBorder={i > 0}
-        className={i + 1 === l ? 'mb-24' : ''}
+        className={i + 1 === l ? 'mb-48' : ''}
       />
     )
   })

--- a/src/components/navi/SubMenu.jsx
+++ b/src/components/navi/SubMenu.jsx
@@ -36,7 +36,7 @@ const SubMenuItems = ({ items, isOpen, level }) => {
   return (
     <ul
       className={cls('ifu-mainmenu__submenu', {
-        'opacity-0 max-h-0': !isOpen,
+        'opacity-0 hidden max-h-0': !isOpen,
         'opacity-100 transition-all max-h-full  duration-300': isOpen,
       })}
     >


### PR DESCRIPTION
The ticket can be found here [IFU-876](https://helsinkisolutionoffice.atlassian.net/browse/IFU-876).

As the ticket mentions, there are invisible links on the left sidebar/menu under Oulu and they're clickable. My colleague thoughts, that this might happen to every city element on that menu, but has an effect only on the last one.  You can verify this on the live/product site, [infofinland](https://infofinland.fi). 

So I added a `hidden` class to the sub menus ul elements, because `opacity-0` class wasn't enough. I think the `opacity-0` just hides them, so they're not visible, but they remain clickable. Also I leaved the `opacity` class there,  because it might have something to do with the `accordion`.

After I added the `hidden` class to the submenu, it removed the white space under Oulu, what is needed according to our PO. So I added some `margin-bottom` and `padding-bottom` to the `MenuGroup.jsx`. So there should be around the same amount of white space now, that we have on the production site. 

So the invisible links should be gone now and the white space has been fixed, but If there is a wiser way to do this, I'm all ears. 



[IFU-876]: https://helsinkisolutionoffice.atlassian.net/browse/IFU-876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ