### PR TITLE
IFU-920: Add missing / out of sync lock file

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,10 +1474,10 @@
     methods "^1.1.2"
     path-to-regexp "^6.1.0"
 
-"@next/bundle-analyzer@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-12.3.4.tgz#37c587525288a3dea64213c991590532246e8bb8"
-  integrity sha512-eKjgRICzbLTmod0UnJcArFVs5uEAiuZwB6NCf84m+btW7jdylUVoOYf1wi5tA14xk5L9Lho7Prm6/XJ8gxYzfQ==
+"@next/bundle-analyzer@12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@next/bundle-analyzer/-/bundle-analyzer-12.1.4.tgz#22afb920b769a54a8da118af0786df0a1f4fca47"
+  integrity sha512-Xw3gxBTOAS5bcayUl2hDYeCbAFIR+7poiGW4Wi/KGcsjgVRetKBS6akZ1AZsz36CUOdCxajKO45B6CeAaKtcqA==
   dependencies:
     webpack-bundle-analyzer "4.3.0"
 
@@ -1485,11 +1485,6 @@
   version "12.1.5"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-12.1.5.tgz#a21ba6708022d630402ca2b340316e69a0296dfc"
   integrity sha512-+34yUJslfJi7Lyx6ELuN8nWcOzi27izfYnZIC1Dqv7kmmfiBVxgzR3BXhlvEMTKC2IRJhXVs2FkMY+buQe3k7Q==
-
-"@next/env@12.3.4":
-  version "12.3.4"
-  resolved "https://registry.yarnpkg.com/@next/env/-/env-12.3.4.tgz#c787837d36fcad75d72ff8df6b57482027d64a47"
-  integrity sha512-H/69Lc5Q02dq3o+dxxy5O/oNxFsZpdL6WREtOOtOM1B/weonIwDXkekr1KV5DPVPr12IHFPrMrcJQ6bgPMfn7A==
 
 "@next/env@12.3.4":
   version "12.3.4"


### PR DESCRIPTION
Basically the ticket says it all, see [IFU-920](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IFU/boards/198?selectedIssue=IFU-920). 

Added the missing / out of sync lock file. 

To test this, so basically what I think what should happen is when you run the `yarn` command, there shouldn't be visible changes. Also you can try to do the testing in that way, that you remove the `node_modules` folder and run the `yarn` command again and then again, there shouldn't be no visible changes, and by that I mean, that the `git` doesn't recognise that any files have changed. So hopefully this fixes the problem, that the `package.json` and `yarn.lock` are synced again. 

Actually one thing you can of course test, is after you have runned the `yarn` command, run `yarn dev` and goto [localhost:3000](http://localhost:3000) and see that the page actually runs.

[IFU-920]: https://helsinkisolutionoffice.atlassian.net/browse/IFU-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ