### PR TITLE
IFU-952 - fixed 2 links on Sitemap

### DIFF
--- a/pages/sitemap.jsx
+++ b/pages/sitemap.jsx
@@ -97,30 +97,34 @@ const SitemapList = ({ urls, name }) => {
 }
 
 export default function SiteMap({ node, urls, menus }) {
-  const { locale } = useRouter
+  const { locale } = useRouter()
   const { t } = useTranslation('common')
   const { DRUPAL_MENUS } = getConfig().publicRuntimeConfig
 
   return (
     <>
       <CommonHead key={`head-sitemap-${node?.id}`} node={node} />
-      <SecondaryLayout node={node} menus={menus}>
-        <Block>
-          <h1 className="mt-16 mb-8 text-h1 md:text-h1xl">{node?.title}</h1>
-          <SitemapList
+       <SecondaryLayout node={node} menus={menus}>
+         <Block>
+           <h1 className="mt-16 mb-8 text-h1 md:text-h1xl">{node?.title}</h1>
+           <SitemapList
             urls={[
               { url: `/${locale}`, title: t('breadcrumbs.frontpage') },
               ...urls?.main,
             ]}
             name={DRUPAL_MENUS.MAIN}
           />
-          <SitemapList
-            urls={[...urls[DRUPAL_MENUS.CITIES_LANDING], ...urls?.cities]}
-            name={DRUPAL_MENUS.CITIES}
-          />
-          <SitemapList urls={urls?.about} name={DRUPAL_MENUS.ABOUT} />
-        </Block>
-      </SecondaryLayout>
+
+           <SitemapList
+             urls={[
+               { url: `/${locale}/${DRUPAL_MENUS.CITIES}`, title: t('frontpage.cities.title') },
+               ...urls?.cities,
+             ]}
+             name={DRUPAL_MENUS.CITIES}
+           />
+           <SitemapList urls={urls?.about} name={DRUPAL_MENUS.ABOUT} />
+         </Block>
+       </SecondaryLayout>
     </>
   )
 }

--- a/src/components/article/ArticleHeading.jsx
+++ b/src/components/article/ArticleHeading.jsx
@@ -21,17 +21,6 @@ export default function ArticleHeading({
   return (
     <div className={titleMargin}>
       <div className={cls({ 'absolute bottom-5 md:bottom-8': !forHeroImage })}>
-        {locale !== fallbackLocale && (
-          <span
-            lang="fi"
-            className={cls('block text-action mb-3', {
-              'text-gray-darker': forHeroImage,
-              'text-bodytext-color mt-6': !forHeroImage,
-            })}
-          >
-            {fiTitle}
-          </span>
-        )}
         {/* article title / hero text */}
         <h1
           className={cls(


### PR DESCRIPTION
What was fixed:
The Cities and Homepage links were misdirecting on the sitemap.

How to test:
- Check out this branch
- Run `yarn dev` in the frontend.
- Go to `localhost:3000/sitemap` and test those two links. 

This isn't an ideal way to get the Cities URL, in case anyone has a better idea