### PR TITLE
WIP: IFU-959 -  screen reader text

### DIFF
--- a/styles/utilities.css
+++ b/styles/utilities.css
@@ -4,6 +4,20 @@
       0px 0px 50px rgb(0 0 0 / 30%);
   }
 
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    border: 0;
+    padding: 0;
+
+    white-space: nowrap;
+    clip-path: inset(100%);
+    clip: rect(0 0 0 0);
+    overflow: hidden;
+  }
+
   @screen lg {
     /* List of upscaled text elements for chinese characters */
     /*  Home hero title */


### PR DESCRIPTION
WIP - this CSS should be correct, but I had trouble getting it to compile

What was fixed
CSS to hide the screen reader text on the Accessibility page

To test:
- check out this branch
- Figure out how to compile the CSS
- Visit the http://localhost:3000/fi/accessibility page
- Verify that the emails and links like this ` infofinland@hel.fi (Linkki avaa oletussähköpostiohjelman) ` don't have the text in parenthesis visible anymore