### PR TITLE
IFU-952 - removed some unneeded variables that weren't passing linter

### DIFF
--- a/src/components/article/ArticleHeading.jsx
+++ b/src/components/article/ArticleHeading.jsx
@@ -1,20 +1,14 @@
 import cls from 'classnames'
 import { longTextClass } from '@/components/Typo'
 import { IconCalendar } from '@/components/Icons'
-import { i18n } from '@/next-i18next.config'
-import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
-
-const { fallbackLocale } = i18n
 
 export default function ArticleHeading({
   forHeroImage = false,
   title,
   date,
   themeHero,
-  fiTitle,
 }) {
-  const { locale } = useRouter()
   const { t } = useTranslation('common')
 
   const titleMargin = themeHero ? 'ifu-block--article' : 'ifu-block--hero'


### PR DESCRIPTION
This is based on the sitemap fix that was already merged, but removing some things that were not passing linter. 

To test: merge it and see if the deployment runs.

You can also try `yarn build && yarn start` to test locally and verify there are no errors.