### PR TITLE
add the page name back where it's supposed to be

### DIFF
--- a/src/components/article/ArticleHeading.jsx
+++ b/src/components/article/ArticleHeading.jsx
@@ -1,20 +1,37 @@
 import cls from 'classnames'
 import { longTextClass } from '@/components/Typo'
 import { IconCalendar } from '@/components/Icons'
+import { i18n } from '@/next-i18next.config'
+import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
+
+const { fallbackLocale } = i18n
 
 export default function ArticleHeading({
   forHeroImage = false,
   title,
   date,
   themeHero,
+  fiTitle,
 }) {
+  const { locale } = useRouter()
   const { t } = useTranslation('common')
 
   const titleMargin = themeHero ? 'ifu-block--article' : 'ifu-block--hero'
   return (
     <div className={titleMargin}>
       <div className={cls({ 'absolute bottom-5 md:bottom-8': !forHeroImage })}>
+        {locale !== fallbackLocale && (
+          <span
+            lang="fi"
+            className={cls('block text-action mb-3', {
+              'text-gray-darker': forHeroImage,
+              'text-bodytext-color mt-6': !forHeroImage,
+            })}
+          >
+            {fiTitle}
+          </span>
+        )}
         {/* article title / hero text */}
         <h1
           className={cls(


### PR DESCRIPTION
These lines were removed for no apparent reason. 

Setup:
- Setup infofinland-site
- on ui: `git checkout UHF-10105`
- run `yarn dev`

How to test:
- Go to any page on any language other than finnish
  - For example the housing - rental home (asuminen - vuokra-asunto) (mentioned on bug ticket)
- Between hero-image and the title, there should be the name of the page in finnish.