### PR TITLE
UHF-9773: performance

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -74,8 +74,6 @@ const config = {
   i18n,
   reactStrictMode: true,
   poweredByHeader: false,
-  // Try this if weird caching issues still persist
-  generateEtags: false,
   env,
   publicRuntimeConfig,
   serverRuntimeConfig,

--- a/pages/[[...slug]].jsx
+++ b/pages/[[...slug]].jsx
@@ -188,6 +188,9 @@ export async function getStaticProps(context) {
     }
   }
 
+  // Next.js complains about large page data on every page. The major
+  // contributor seems to be huge menu structure that is included on each page.
+  // See more info here: https://nextjs.org/docs/messages/large-page-data.
   let menus = {}
   if (node.field_layout === 'small') {
     menus = await getCachedAboutMenus({ locale, withAuth })

--- a/src/components/navi/SubMenu.jsx
+++ b/src/components/navi/SubMenu.jsx
@@ -12,7 +12,7 @@ const SubMenuItem = ({ title, url, selected, items, level, isOpen }) => {
       <Link passHref href={url} locale={false} prefetch={false}>
         <a
           aria-current={selected ? 'page' : undefined}
-          tabIndex={isOpen ? '0' : '-1'}
+          tabIndex={isOpen ? 0 : -1}
           className={cls('ifu-mainmenu__item--subitem', {
             'ps-10 ': level === 1,
             'ps-14': level === 2,

--- a/src/lib/DRUPAL_API_TYPES.js
+++ b/src/lib/DRUPAL_API_TYPES.js
@@ -31,6 +31,7 @@ export const CONTENT_TYPES = {
   LANGUAGE: 'taxonomy_term--language',
   MUNICIPALITY: 'taxonomy_term--municipalitys',
   HERO_COLOR: 'taxonomy_term--colors',
+  MENU_LINK_CONTENT: 'menu_link_content--menu_link_content',
 }
 
 export const TEXT_HTML_FORMAT = 'full_html'

--- a/src/lib/drupal-client.js
+++ b/src/lib/drupal-client.js
@@ -1,5 +1,6 @@
 import { DrupalClient } from 'next-drupal'
 import getConfig from 'next/config'
+
 export const getDrupalClient = (withAuth) => {
   const {
     NEXT_PUBLIC_DRUPAL_BASE_URL,

--- a/src/lib/query-params.js
+++ b/src/lib/query-params.js
@@ -183,6 +183,11 @@ export const getMunicipalityParams = () =>
     .addFields(CONTENT_TYPES.MUNICIPALITY, ['id', 'name'])
     .getQueryObject()
 
+export const getMenuParams = () =>
+  new DrupalJsonApiParams()
+    .addFields(CONTENT_TYPES.MENU_LINK_CONTENT, ['id', 'url', 'title','parent'])
+    .getQueryObject()
+
 export const getLocalInfoParams = () =>
   new DrupalJsonApiParams()
     .addInclude([

--- a/src/lib/ssr-api.js
+++ b/src/lib/ssr-api.js
@@ -1,7 +1,7 @@
 import { DrupalJsonApiParams } from 'drupal-jsonapi-params'
 import getConfig from 'next/config'
 import { CONTENT_TYPES, NODE_TYPES } from './DRUPAL_API_TYPES'
-import { getMunicipalityParams, getThemeHeroParams } from './query-params'
+import { getMenuParams, getMunicipalityParams, getThemeHeroParams } from './query-params'
 import { getHeroFromNode, getRedirect } from './ssr-helpers'
 
 import { getQueryParamsFor } from './query-params'
@@ -55,10 +55,12 @@ export const getCachedAboutMenus = async ({ locale, withAuth }) => {
     drupal.getMenu(DRUPAL_MENUS.ABOUT, {
       locale,
       defaultLocale: NO_DEFAULT_LOCALE,
+      params: getMenuParams(),
     }),
     drupal.getMenu(DRUPAL_MENUS.FOOTER, {
       locale,
       defaultLocale: NO_DEFAULT_LOCALE,
+      params: getMenuParams(),
     }),
   ])
 
@@ -84,6 +86,7 @@ export const getCachedMainMenus = async ({ locale, withAuth }) => {
     drupal.getMenu(DRUPAL_MENUS.MAIN, {
       locale,
       defaultLocale: NO_DEFAULT_LOCALE,
+      params: getMenuParams(),
     }),
   ])
 
@@ -109,6 +112,7 @@ export const getCachedCitiesMenus = async ({ locale, withAuth }) => {
     drupal.getMenu(DRUPAL_MENUS.CITIES, {
       locale,
       defaultLocale: NO_DEFAULT_LOCALE,
+      params: getMenuParams(),
     }),
   ])
 
@@ -128,6 +132,7 @@ export const getMainMenus = async ({ locale, withAuth }) => {
       .getMenu(DRUPAL_MENUS.MAIN, {
         locale,
         defaultLocale: NO_DEFAULT_LOCALE,
+        params: getMenuParams(),
       })
       .catch((e) => {
         logger.error('Error fetching main menu:', { e, locale })
@@ -138,6 +143,7 @@ export const getMainMenus = async ({ locale, withAuth }) => {
       .getMenu(DRUPAL_MENUS.CITIES_LANDING, {
         locale,
         defaultLocale: NO_DEFAULT_LOCALE,
+        params: getMenuParams(),
       })
       .catch((e) => {
         logger.error('Error fetching cities-main menu:', { e, locale })
@@ -148,6 +154,7 @@ export const getMainMenus = async ({ locale, withAuth }) => {
       .getMenu(DRUPAL_MENUS.CITIES, {
         locale,
         defaultLocale: NO_DEFAULT_LOCALE,
+        params: getMenuParams(),
       })
       .catch((e) => {
         logger.error('Error fetching cities menu:', { e, locale })
@@ -158,6 +165,7 @@ export const getMainMenus = async ({ locale, withAuth }) => {
       .getMenu(DRUPAL_MENUS.FOOTER, {
         locale,
         defaultLocale: NO_DEFAULT_LOCALE,
+        params: getMenuParams(),
       })
       .catch((e) => {
         logger.error('Error fetching footer menu:', { e, locale })

--- a/src/lib/ssr-api.js
+++ b/src/lib/ssr-api.js
@@ -310,7 +310,13 @@ export const getMunicipalities = async ({ locale, withAuth }) =>
     locale,
     defaultLocale: NO_DEFAULT_LOCALE,
     params: getMunicipalityParams(),
-  })
+  }).then(
+    // Filter unused properties:
+    municipalities => municipalities.map(municipality => ({
+      id: municipality.id,
+      name: municipality.name,
+    }))
+  )
 
 export const getFeedbackPage = async ({ locale }) => {
   const { FEEDBACK_PAGE_PATH } = getConfig().serverRuntimeConfig


### PR DESCRIPTION
# [UHF-9773](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9773)

General performance improvements. Filtering menu properties optimizes (uncompressed) page data size from ~1.2 MB to ~300 kb. The recommended size is less than 128 kB.

Etag generation is re-enabled, which should further reduce network usage.

## How to install

- Run `make fresh` on backend
- Run `nvm use; npm install -g yarn`
- Run `yarn build; yarn start` (prefetching is disabled on `yarn run dev`)

## How to test

- [ ] From backend, open `docker compose logs app --follow`. Verify that Next.js caches backend requests.
- [ ] Go to `http://localhost:3000`. Browse the page with network tab open in your browsers development tools.
- [ ] Is it OK to enable etags?

## Other pull requests

- https://github.com/City-of-Helsinki/infofinland-ui/pull/277

[UHF-9773]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ