### PR TITLE
UHF-9773: Disable prefetching

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -74,6 +74,8 @@ const config = {
   i18n,
   reactStrictMode: true,
   poweredByHeader: false,
+  // Try this if weird caching issues still persist
+  generateEtags: false,
   env,
   publicRuntimeConfig,
   serverRuntimeConfig,

--- a/src/components/cities/LocalInformationSWR.jsx
+++ b/src/components/cities/LocalInformationSWR.jsx
@@ -12,6 +12,7 @@ import { ExternalLinkCollection } from '../article/ReadMoreBlock'
 import ParseHtml from '@/components/ParseHtml'
 import { getLocalInformation } from '@/lib/client-api'
 import { nodeIdAtom } from '@/src/store'
+import { useRef } from 'react'
 
 const SWRContent = ({ city, isOpen }) => {
   const { t } = useTranslation('common')
@@ -29,9 +30,13 @@ const SWRContent = ({ city, isOpen }) => {
   const content = field_municipality_info?.find(
     ({ field_national_page: { id } }) => id === pageId
   )
+
+  const nodeRef = useRef(null)
+
   return (
     <CSSTransition
       in={isOpen}
+      nodeRef={nodeRef}
       classNames={{
         appear: 'ifu-local-info__content--appear',
         appearActive: 'ifu-local-info__content--appear-active',

--- a/src/components/navi/Menu.jsx
+++ b/src/components/navi/Menu.jsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react'
-import Link from 'next/link'
 import cls from 'classnames'
 import SubMenu from '@/components/navi/SubMenu'
 import useLocalizedPath from '@/hooks/useRouterWithLocalizedPath'
@@ -21,6 +20,7 @@ const getThemeIndexByPathName = ({ items, path }) => {
   })
   return index
 }
+
 const TopMenuItem = ({
   title,
   url,
@@ -38,19 +38,18 @@ const TopMenuItem = ({
       })}
     >
       {!items && (
-        <Link href={url} locale={false} prefetch={false}>
-          <a
-            aria-current={selected ? 'page' : undefined}
-            className={cls('ifu-mainmenu__item--link', {
-              'font-bold': selected,
-              'border-white': !selected,
-              'border-blue':
-                (selected && (!isOpen || !items)) || selectedIsHidden,
-            })}
-          >
-            {title}
-          </a>
-        </Link>
+        <a
+          href={url}
+          aria-current={selected ? 'page' : undefined}
+          className={cls('ifu-mainmenu__item--link', {
+            'font-bold': selected,
+            'border-white': !selected,
+            'border-blue':
+              (selected && (!isOpen || !items)) || selectedIsHidden,
+          })}
+        >
+          {title}
+        </a>
       )}
 
       {items && (

--- a/src/components/navi/Menu.jsx
+++ b/src/components/navi/Menu.jsx
@@ -4,6 +4,7 @@ import SubMenu from '@/components/navi/SubMenu'
 import useLocalizedPath from '@/hooks/useRouterWithLocalizedPath'
 import { findRootForPath, getRootPages } from '@/lib/menu-utils'
 import { IconExclamationCircle } from '../Icons'
+import NaviLink from "@/components/navi/NaviLink";
 
 const getThemeIndexByPathName = ({ items, path }) => {
   let index
@@ -38,7 +39,7 @@ const TopMenuItem = ({
       })}
     >
       {!items && (
-        <a
+        <NaviLink
           href={url}
           aria-current={selected ? 'page' : undefined}
           className={cls('ifu-mainmenu__item--link', {
@@ -49,7 +50,7 @@ const TopMenuItem = ({
           })}
         >
           {title}
-        </a>
+        </NaviLink>
       )}
 
       {items && (

--- a/src/components/navi/NaviLink.jsx
+++ b/src/components/navi/NaviLink.jsx
@@ -1,0 +1,19 @@
+import router from 'next/router';
+
+/**
+ * Navigation link without Next.js prefetch.
+ */
+function NaviLink({ href, children, ...props }) {
+  function handleOnClick(e) {
+    e.preventDefault();
+    router.push(href);
+  }
+
+  return (
+    <a href={href} {...props} onClick={handleOnClick}>
+      {children}
+    </a>
+  );
+}
+
+export default NaviLink;

--- a/src/components/navi/SubMenu.jsx
+++ b/src/components/navi/SubMenu.jsx
@@ -1,5 +1,4 @@
 import { IconAngleDown, IconAngleUp } from '@/components/Icons'
-import Link from 'next/link'
 import cls from 'classnames'
 import useLocalizedPath from '@/hooks/useRouterWithLocalizedPath'
 import { useTranslation } from 'next-i18next'
@@ -9,20 +8,19 @@ import { useRef } from 'react'
 const SubMenuItem = ({ title, url, selected, items, level, isOpen }) => {
   return (
     <li className="block">
-      <Link passHref href={url} locale={false} prefetch={false}>
-        <a
-          aria-current={selected ? 'page' : undefined}
-          tabIndex={isOpen ? 0 : -1}
-          className={cls('ifu-mainmenu__item--subitem', {
-            'ps-10 ': level === 1,
-            'ps-14': level === 2,
-            'border-s-5 border-blue/75 hover:border-blue  font-bold': selected,
-            'border-s-5 border-white ': !selected,
-          })}
-        >
-          {title}
-        </a>
-      </Link>
+      <a
+        href={url}
+        aria-current={selected ? 'page' : undefined}
+        tabIndex={isOpen ? 0 : -1}
+        className={cls('ifu-mainmenu__item--subitem', {
+          'ps-10 ': level === 1,
+          'ps-14': level === 2,
+          'border-s-5 border-blue/75 hover:border-blue  font-bold': selected,
+          'border-s-5 border-white ': !selected,
+        })}
+      >
+        {title}
+      </a>
       {items && (
         <SubMenuItems items={items} level={level + 1} isOpen={isOpen} />
       )}
@@ -98,16 +96,15 @@ const SubMenu = ({
             'border-white hover:border-gray-white': !secondarySelection,
           })}
         >
-          <Link passHref href={url} prefetch={false} locale={false}>
-            <a
-              className="flex-grow py-4"
-              aria-current={selected ? 'page' : undefined}
-            >
-              <span className={cls('block', { 'font-bold': selected })}>
-                {title}
-              </span>
-            </a>
-          </Link>
+          <a
+            href={url}
+            className="flex-grow py-4"
+            aria-current={selected ? 'page' : undefined}
+          >
+            <span className={cls('block', { 'font-bold': selected })}>
+              {title}
+            </span>
+          </a>
           <div className="flex-none">
             <button
               className="inline-flex relative justify-center items-center w-16 h-12"

--- a/src/components/navi/SubMenu.jsx
+++ b/src/components/navi/SubMenu.jsx
@@ -4,11 +4,12 @@ import useLocalizedPath from '@/hooks/useRouterWithLocalizedPath'
 import { useTranslation } from 'next-i18next'
 import { useEffect } from 'react'
 import { useRef } from 'react'
+import NaviLink from "@/components/navi/NaviLink";
 
 const SubMenuItem = ({ title, url, selected, items, level, isOpen }) => {
   return (
     <li className="block">
-      <a
+      <NaviLink
         href={url}
         aria-current={selected ? 'page' : undefined}
         tabIndex={isOpen ? 0 : -1}
@@ -20,7 +21,7 @@ const SubMenuItem = ({ title, url, selected, items, level, isOpen }) => {
         })}
       >
         {title}
-      </a>
+      </NaviLink>
       {items && (
         <SubMenuItems items={items} level={level + 1} isOpen={isOpen} />
       )}
@@ -96,7 +97,7 @@ const SubMenu = ({
             'border-white hover:border-gray-white': !secondarySelection,
           })}
         >
-          <a
+          <NaviLink
             href={url}
             className="flex-grow py-4"
             aria-current={selected ? 'page' : undefined}
@@ -104,7 +105,7 @@ const SubMenu = ({
             <span className={cls('block', { 'font-bold': selected })}>
               {title}
             </span>
-          </a>
+          </NaviLink>
           <div className="flex-none">
             <button
               className="inline-flex relative justify-center items-center w-16 h-12"


### PR DESCRIPTION
# [UHF-9773](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9773)

Disable prefetching from menu links.

## How to install

- Run `make fresh` on backend
- Run `nvm use; npm install -g yarn`
- Run `yarn build; yarn start` (prefetching is disabled on `yarn run dev`)

## How to test

- [ ] Go to `http://localhost:3000`. Browse the page with network tab open in your browsers development tools.
- [ ] Go to http://localhost:3000/en/moving-to-finland/eu-citizens, scroll to Local information, Click Select a municipality, select Helsinki.
  - The page should not crash, you should not see JS errors in browser console.

This action crashes on https://infofinland.test.hel.ninja/en/moving-to-finland/eu-citizens.

## Other pull requests

- https://github.com/City-of-Helsinki/infofinland-ui/pull/277

[UHF-9773]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ