### PR TITLE
UHF-X: Fix local information block

### DIFF
--- a/src/components/cities/LocalInformationSWR.jsx
+++ b/src/components/cities/LocalInformationSWR.jsx
@@ -12,6 +12,7 @@ import { ExternalLinkCollection } from '../article/ReadMoreBlock'
 import ParseHtml from '@/components/ParseHtml'
 import { getLocalInformation } from '@/lib/client-api'
 import { nodeIdAtom } from '@/src/store'
+import { useRef } from 'react'
 
 const SWRContent = ({ city, isOpen }) => {
   const { t } = useTranslation('common')
@@ -29,9 +30,13 @@ const SWRContent = ({ city, isOpen }) => {
   const content = field_municipality_info?.find(
     ({ field_national_page: { id } }) => id === pageId
   )
+
+  const nodeRef = useRef(null)
+
   return (
     <CSSTransition
       in={isOpen}
+      nodeRef={nodeRef}
       classNames={{
         appear: 'ifu-local-info__content--appear',
         appearActive: 'ifu-local-info__content--appear-active',


### PR DESCRIPTION
## How to test
- [ ] Go to http://localhost:3000/en/moving-to-finland/eu-citizens, scroll to `Local information`, Click `Select a municipality`, select `Helsinki`.
  - The page should not crash, you should not see JS errors in browser console.

This action crashes on https://infofinland.test.hel.ninja/en/moving-to-finland/eu-citizens.