### PR TITLE
UHF-11043: Fix wrong opacity on disclaimer text

### DIFF
--- a/styles/components.askem.css
+++ b/styles/components.askem.css
@@ -201,6 +201,7 @@
   .askem-plugin .askem-inputs .askem-input-disclaimer {
     color: var(--disclaimer-color);
     font-size: 16px;
+    opacity: 1;
   }
 
   /* Override some of the Askem submit button styles. */


### PR DESCRIPTION
# [UHF-11043](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11043)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

## How to install

- Run `make fresh` on backend
- Run `nvm use; npm install -g yarn`
- Run `yarn build; yarn start` (prefetching is disabled on `yarn run dev`)

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that Askem disclaimer text doesn't have opacity anymore.
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

[UHF-11043]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ