### PR TITLE
UHF-11217: Fix the title and description handling when field_metatags values are set in the backend

### DIFF
--- a/src/components/layout/CommonHead.jsx
+++ b/src/components/layout/CommonHead.jsx
@@ -5,12 +5,17 @@ import useRouterWithLocalizedPath from '@/hooks/useRouterWithLocalizedPath'
 export const FALLBACK_TITLE = 'infofinland.fi'
 
 const CommonHead = ({ node }) => {
-  const { title, field_description, id, field_metatags } = node
+  const { title: field_title, field_description, id, field_metatags } = node
   const { src = '' } = getHeroFromNode(node)
   const { SITE_HOST } = getConfig().publicRuntimeConfig
   const { localePath } = useRouterWithLocalizedPath()
   let url
-  const description = field_metatags?.description || field_description || ''
+  const metatags =
+    typeof field_metatags === 'string'
+      ? JSON.parse(field_metatags)
+      : field_metatags || {}
+  const title = metatags?.title || field_title || FALLBACK_TITLE
+  const description = metatags?.description || field_description || ''
   const idKey = (token) => `${token}-${id}`
   try {
     // Remove any trailing slashes.
@@ -28,9 +33,7 @@ const CommonHead = ({ node }) => {
   return (
     <>
       <Head>
-        <title key="title">
-          {field_metatags?.title || title || FALLBACK_TITLE}
-        </title>
+        <title key="title">{title}</title>
         <link rel="canonical" href={url} />
         <meta
           name="viewport"


### PR DESCRIPTION
# [UHF-11217](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11217)

## What was done

The computed metatags field, which was introduced in this issue (https://www.drupal.org/project/metatag/issues/2945817) for does not seem to exist in the backend. Attempts to recreate the field manually was not successful. 

The only available field for extracting the metatags is the field_metatags, which returns a json string.

This fixes the (temporarily) issue by parsing the json string of field_metatags.

## How to install

- Run `make fresh` on backend
- Run `nvm use; npm install -g yarn`
- Run `yarn build; yarn start` (prefetching is disabled on `yarn run dev`)

## How to test

* [x] Edit one of the pages
* [x] Manually set the metatag title and description (on the side bar)
* [x] Save the page and view the page in Next.JS app
* [x] Inspect the metatag values in the DOM, they should show the correct overridden metatags which are set in the backend

## Continuous documentation

* [ ] This change doesn't require updates to the documentation

[UHF-11217]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ