### PR TITLE
UHF-11819: Updating query string sanitiser

### DIFF
--- a/pages/search.jsx
+++ b/pages/search.jsx
@@ -21,8 +21,14 @@ import {
 import Pagination from '@/components/search/Pagination'
 import SearchResults from '@/components/search/SearchResults'
 import { CACHE_HEADERS_60S } from '@/cache-headers'
+import { sanitiseStrict } from '@/lib/utils'
 
 export async function getServerSideProps(context) {
+  // Sanitise all query params in context.
+  for (const param in context.query) {
+    context.query[param] = sanitiseStrict(context.query[param])
+  }
+
   const { SEARCH_PAGE_PATH } = getConfig().serverRuntimeConfig
 
   const menus = await getCachedMenus(context.locale)

--- a/src/components/search/SearchBar.jsx
+++ b/src/components/search/SearchBar.jsx
@@ -3,7 +3,7 @@ import useSearchRoute from '@/hooks/useSearchRoute'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'next-i18next'
 import LanguageFilters from '@/components/search/LanguageFilters'
-import DOMPurify from "isomorphic-dompurify";
+import { sanitiseStrict } from '@/lib/utils'
 
 const SearchBar = ({ search }) => {
   // Sync search field with URL
@@ -25,7 +25,9 @@ const SearchBar = ({ search }) => {
           placeholder={t('search.placeholder')}
           name="search"
           value={qw || ''}
-          onChange={({ target: { value } }) => setQuery(DOMPurify.sanitize(value))}
+          onChange={({ target: { value } }) =>
+            setQuery(sanitiseStrict(value))
+          }
           className="ifu-search__input--page"
         />
         <button className="inline-flex flex-none items-center w-12 h-12">

--- a/src/components/search/TopSearch.jsx
+++ b/src/components/search/TopSearch.jsx
@@ -6,7 +6,7 @@ import { useAtom } from 'jotai'
 import { searchQueryValue } from '@/src/store'
 import useSearchRoute from '@/hooks/useSearchRoute'
 import dynamic from 'next/dynamic'
-import DOMPurify from "isomorphic-dompurify";
+import { sanitiseStrict } from '@/lib/utils'
 
 const SearchBar = dynamic(() => import('./TopSearchBar'), { ssr: false })
 
@@ -28,7 +28,8 @@ const TopSearch = () => {
   }
   const onSubmit = useSearchRoute({ onSubmit: reset, search: query })
 
-  const onChange = ({ target: { value } }) => setQuery(DOMPurify.sanitize(value))
+  const onChange = ({ target: { value } }) =>
+    setQuery(sanitiseStrict(value))
 
   return (
     <>

--- a/src/lib/elasticsearch.js
+++ b/src/lib/elasticsearch.js
@@ -2,7 +2,7 @@ import getConfig from 'next/config'
 import { Client } from '@elastic/elasticsearch'
 import { HIGHLIGHT_CLASS } from '@/components/search/Result'
 import isString from 'lodash/isString'
-import DOMPurify from "isomorphic-dompurify";
+import { sanitiseStrict } from '@/lib/utils'
 // import logger from '@/logger'
 const logger = console
 
@@ -87,7 +87,7 @@ export function getQuery(q) {
 }
 
 export function getSearchParamsFromQuery({ query, locale }) {
-  const q = DOMPurify.sanitize((query?.search || query.q || '').trim())
+  const q = sanitiseStrict((query?.search || query.q || '').trim())
   const size = Number(query?.size) || DEFAULT_SIZE
   let languages = Array.isArray(query?.languages)
     ? query?.languages

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,6 @@
+import DOMPurify from 'isomorphic-dompurify'
+
+export const sanitiseStrict = (value) =>
+  DOMPurify.sanitize(value, {
+    USE_PROFILES: { html: false },
+  })


### PR DESCRIPTION
# [UHF-11819](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11819)

Complements #305 .

## What was done

- Updates the sanitiser to remove all html from query parameters instead of just potentially dangerous elements & attributes.
- Adds sanitation to all search route query parameters to make sure no unsanitised data ends up in hydration data.

## How to install

See #305 

## How to test

- [ ] Check that search input is sanitised
  - Go to http://localhost:3000/fi/search
  - Try searching with `<img src="http://url.to.file.which/not.exist" onerror=alert(document.cookie);>` the input is sanitised already on paste, leaving the input empty
  - Try searching with `helsinki <img src="http://url.to.file.which/not.exist" onerror=alert(document.cookie);>` the input is sanitised already on paste, leaving only `helsinki`
  - Try searching with malicious content in a query string: http://localhost:3000/fi/search?search=%3Cimg%20src=%22http://url.to.file.which/not.exist%22%20onerror=alert(document.cookie);%3E ; search input should display a sanitised version (which here is empty)
  - Try searching with malicious content in a query string: http://localhost:3000/fi/search?search=helsinki+%3Cimg%20src=%22http://url.to.file.which/not.exist%22%20onerror=alert(document.cookie);%3E ; search input should display a sanitised version (which here is `helsinki`)
  - Also try searching the page source for `not.exist`; it should only appear in language translation links, but no longer as part of `__NEXT_DATA__` (hydration data).



[UHF-11819]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ