### PR TITLE
UHF-11694: Fixing a hydration error when url contains an anchor hash.

### DIFF
--- a/src/hooks/useRouterWithLocalizedPath.js
+++ b/src/hooks/useRouterWithLocalizedPath.js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 export default function useRouterWithLocalizedPath() {
   const router = useRouter()
   const { asPath, locale } = router
-  const localePath = `/${locale}${asPath}`.split('?').shift()
+  const localePath = `/${locale}${asPath}`.split('?').shift().split('#').shift()
 
   return { localePath, ...router }
 }


### PR DESCRIPTION
# [UHF-11694](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11694)

Next.js reports a hydration error when the url contains an anchor hash, like https://infofinland.test.hel.ninja/en/work-and-enterprise/finnish-working-life/right-to-work-in-finland#heading-6242ff89-aa03-444b-99ca-4c4d5f65f34f . Also main menu doesn't display the active menu item properly when this happens.

## What was done

Removed hash from the resolved path that is used for matching the active menu item.

## How to install

- Run `make fresh` on backend
- Run `nvm use; npm install -g yarn`
- Run `yarn build; yarn start` (prefetching is disabled on `yarn run dev`)

## How to test

* Go to http://localhost:3000/en/work-and-enterprise/finnish-working-life/right-to-work-in-finland#heading-6242ff89-aa03-444b-99ca-4c4d5f65f34f
  * [ ] Check that console doesn't show any hydration errors
  * [ ] Check that left side menu has the proper submenu open and the active menu item is highlighted
