### PR TITLE
UHF-12421: Forbid all search engines

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -120,6 +120,19 @@ const config = {
       },
     ]
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Robots-Tag',
+            value: 'noindex, nofollow',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 module.exports = withBundleAnalyzer(config)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,3 @@
-# *
+# Block all search engines from indexing this site
 User-agent: *
-Allow: /*
-Disallow: /api/
-Disallow: /500
-Disallow: /locales
-Disallow: /404
-
-# Host
-Host: https://www.infofinland.fi
-
-# Sitemaps
-Sitemap: https://www.infofinland.fi/sitemap.xml
-# Sitemap: https://edit.infofinland.fi/default/sitemap.xml
+Disallow: /

--- a/src/components/layout/CommonHead.jsx
+++ b/src/components/layout/CommonHead.jsx
@@ -41,6 +41,7 @@ const CommonHead = ({ node }) => {
           key={idKey('viewport')}
         />
         <meta charSet="utf-8" key="charset" />
+        <meta name="robots" content="noindex, nofollow" key={idKey('robots')} />
         <meta
           name="description"
           content={description}


### PR DESCRIPTION
# [UHF-12421](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12421)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

The project is winding down. Forbid all search engines & crawlers.

## How to install

- Run `make fresh` on backend
- Run `nvm use; npm install -g yarn`
- Run `yarn build; yarn start`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check http://localhost:3000, `X-Robots-Tag` header should be present.

[UHF-12421]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ